### PR TITLE
Custom files dir for imports

### DIFF
--- a/base/v0_7_exp/schema.go
+++ b/base/v0_7_exp/schema.go
@@ -204,14 +204,19 @@ type Raid struct {
 }
 
 type Resource struct {
-	Compression  *string      `yaml:"compression"`
-	HTTPHeaders  HTTPHeaders  `yaml:"http_headers"`
-	Source       *string      `yaml:"source"`
-	Inline       *string      `yaml:"inline"` // Added, not in ignition spec
-	Local        *string      `yaml:"local"`  // Added, not in ignition spec
-	Verification Verification `yaml:"verification"`
-	InlineButane *string      `yaml:"inline_butane"` // Added, not in ignition spec
-	LocalButane  *string      `yaml:"local_butane"`  // Added, not in ignition spec
+	Compression  *string       `yaml:"compression"`
+	HTTPHeaders  HTTPHeaders   `yaml:"http_headers"`
+	Source       *string       `yaml:"source"`
+	Inline       *string       `yaml:"inline"` // Added, not in ignition spec
+	Local        *string       `yaml:"local"`  // Added, not in ignition spec
+	Verification Verification  `yaml:"verification"`
+	InlineButane *string       `yaml:"inline_butane"` // Added, not in ignition spec
+	LocalButane  *ImportButane `yaml:"local_butane"`  // Added, not in ignition spec
+}
+
+type ImportButane struct {
+	Path     *string `yaml:"path"`
+	FilesDir *string `yaml:"files_dir"`
 }
 
 type SSHAuthorizedKey string

--- a/base/v0_7_exp/translate.go
+++ b/base/v0_7_exp/translate.go
@@ -168,20 +168,33 @@ func TranslateResource(from Resource, options common.TranslateOptions) (to types
 
 	if from.LocalButane != nil {
 		c := path.New("yaml", "local_butane")
+		cc := path.New("yaml", "content")
+		if from.LocalButane.Path == nil {
+			r.AddOnError(cc, fmt.Errorf("content is required"))
+			return
+		}
 
-		contents, err := baseutil.ReadLocalFile(*from.LocalButane, options.FilesDir)
+		cfd := path.New("yaml", "files_dir")
+		if from.LocalButane.FilesDir == util.StrToPtr("") {
+			r.AddOnError(cfd, fmt.Errorf("files_dir cannot be empty"))
+			return
+		}
+
+		contents, err := baseutil.ReadLocalFile(*from.LocalButane.Path, options.FilesDir)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
 		}
 
-		translateButaneResource(contents, c, &r, &to, &tm, options)
+		butaneFilesDir := filepath.Join(options.FilesDir, filepath.Dir(*from.LocalButane.Path), *from.LocalButane.FilesDir)
+
+		translateButaneResource(contents, butaneFilesDir, c, &r, &to, &tm, options)
 	}
 
 	if from.InlineButane != nil {
 		c := path.New("yaml", "inline_butane")
 
-		translateButaneResource([]byte(*from.InlineButane), c, &r, &to, &tm, options)
+		translateButaneResource([]byte(*from.InlineButane), options.FilesDir, c, &r, &to, &tm, options)
 	}
 
 	return
@@ -522,7 +535,8 @@ func contentToURL(contents []byte, c path.ContextPath, r *report.Report, to *typ
 	}
 }
 
-func translateButaneResource(butaneContents []byte, c path.ContextPath, r *report.Report, to *types.Resource, tm *translate.TranslationSet, options common.TranslateOptions) {
+func translateButaneResource(butaneContents []byte, filesDir string, c path.ContextPath, r *report.Report, to *types.Resource, tm *translate.TranslationSet, options common.TranslateOptions) {
+	options.FilesDir = filesDir
 	contents, rp, err := common.TranslateBytes(butaneContents, common.TranslateBytesOptions{
 		Pretty:           false,
 		Raw:              true,

--- a/docs/config-fcos-v1_7-exp.md
+++ b/docs/config-fcos-v1_7-exp.md
@@ -23,7 +23,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -35,7 +37,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -52,7 +56,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
         * **_inline_** (string): the contents of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
         * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
         * **_inline_butane_** (string): the contents of the certificate bundle. Mutually exclusive with `source` and `local`.
-        * **_local_butane_** (string): a local path to the contents of the certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_local_butane_** (object): a local certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+          * **_path_** (string): path to the certificate bundle
+          * **_files_dir_** (string): custom files_dir to use, path local from said file
         * **_compression_** (string): the type of compression used on the certificate bundle (null or gzip). Compression cannot be used with S3.
         * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -101,7 +107,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -113,7 +121,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the fragment
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the fragment (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -156,7 +166,9 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the key file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the key file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.

--- a/docs/config-fiot-v1_1-exp.md
+++ b/docs/config-fiot-v1_1-exp.md
@@ -23,7 +23,9 @@ The Fedora IoT configuration is a YAML document conforming to the following spec
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -35,7 +37,9 @@ The Fedora IoT configuration is a YAML document conforming to the following spec
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -52,7 +56,9 @@ The Fedora IoT configuration is a YAML document conforming to the following spec
         * **_inline_** (string): the contents of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
         * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
         * **_inline_butane_** (string): the contents of the certificate bundle. Mutually exclusive with `source` and `local`.
-        * **_local_butane_** (string): a local path to the contents of the certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_local_butane_** (object): a local certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+          * **_path_** (string): path to the certificate bundle
+          * **_files_dir_** (string): custom files_dir to use, path local from said file
         * **_compression_** (string): the type of compression used on the certificate bundle (null or gzip). Compression cannot be used with S3.
         * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -72,7 +78,9 @@ The Fedora IoT configuration is a YAML document conforming to the following spec
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -84,7 +92,9 @@ The Fedora IoT configuration is a YAML document conforming to the following spec
       * **_inline_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the fragment
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the fragment (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.

--- a/docs/config-flatcar-v1_2-exp.md
+++ b/docs/config-flatcar-v1_2-exp.md
@@ -23,7 +23,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -35,7 +37,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -52,7 +56,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
         * **_inline_** (string): the contents of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
         * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
         * **_inline_butane_** (string): the contents of the certificate bundle. Mutually exclusive with `source` and `local`.
-        * **_local_butane_** (string): a local path to the contents of the certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_local_butane_** (object): a local certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+          * **_path_** (string): path to the certificate bundle
+          * **_files_dir_** (string): custom files_dir to use, path local from said file
         * **_compression_** (string): the type of compression used on the certificate bundle (null or gzip). Compression cannot be used with S3.
         * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -101,7 +107,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -113,7 +121,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
       * **_inline_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the fragment
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the fragment (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -156,7 +166,9 @@ The Flatcar configuration is a YAML document conforming to the following specifi
       * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the key file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the key file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.

--- a/docs/config-openshift-v4_20-exp.md
+++ b/docs/config-openshift-v4_20-exp.md
@@ -26,7 +26,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -38,7 +40,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -55,7 +59,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
         * **_inline_** (string): the contents of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
         * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
         * **_inline_butane_** (string): the contents of the certificate bundle. Mutually exclusive with `source` and `local`.
-        * **_local_butane_** (string): a local path to the contents of the certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_local_butane_** (object): a local certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+          * **_path_** (string): path to the certificate bundle
+          * **_files_dir_** (string): custom files_dir to use, path local from said file
         * **_compression_** (string): the type of compression used on the certificate bundle (null or gzip). Compression cannot be used with S3.
         * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -104,7 +110,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_verification_** (object): options related to the verification of the file.
         * **_hash_** (string): the hash of the file, in the form `<type>-<value>` where type is either `sha512` or `sha256`. If `compression` is specified, the hash describes the decompressed file.
@@ -123,7 +131,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
       * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the key file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the key file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.

--- a/docs/config-r4e-v1_2-exp.md
+++ b/docs/config-r4e-v1_2-exp.md
@@ -23,7 +23,9 @@ The RHEL for Edge configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -35,7 +37,9 @@ The RHEL for Edge configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the config
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -52,7 +56,9 @@ The RHEL for Edge configuration is a YAML document conforming to the following s
         * **_inline_** (string): the contents of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
         * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. The bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
         * **_inline_butane_** (string): the contents of the certificate bundle. Mutually exclusive with `source` and `local`.
-        * **_local_butane_** (string): a local path to the contents of the certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_local_butane_** (object): a local certificate bundle, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+          * **_path_** (string): path to the certificate bundle
+          * **_files_dir_** (string): custom files_dir to use, path local from said file
         * **_compression_** (string): the type of compression used on the certificate bundle (null or gzip). Compression cannot be used with S3.
         * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -72,7 +78,9 @@ The RHEL for Edge configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the file
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the file (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -84,7 +92,9 @@ The RHEL for Edge configuration is a YAML document conforming to the following s
       * **_inline_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
       * **_local_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
       * **_inline_butane_** (string): the contents of the fragment. Mutually exclusive with `source` and `local`.
-      * **_local_butane_** (string): a local path to the contents of the fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_local_butane_** (object): a local fragment, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+        * **_path_** (string): path to the fragment
+        * **_files_dir_** (string): custom files_dir to use, path local from said file
       * **_compression_** (string): the type of compression used on the fragment (null or gzip). Compression cannot be used with S3.
       * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.

--- a/internal/doc/butane.yaml
+++ b/internal/doc/butane.yaml
@@ -39,7 +39,12 @@ resource:
               max: 1.0.0
     - name: local_butane
       after: source
-      desc: "a local path to the contents of the %TYPE%, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`."
+      desc: "a local %TYPE%, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`."
+      children:
+        - name: path
+          desc: "path to the %TYPE%"
+        - name: files_dir
+          desc: "custom files_dir to use, path local from said file"
 
 mode:
   # File mode transforms.
@@ -258,7 +263,7 @@ root:
                 - name: source
                   transforms:
                     - regex: "Supported schemes are .* haven't been modified."
-                      replacement: 'Only the [`data`](https://tools.ietf.org/html/rfc2397) scheme is supported.'
+                      replacement: "Only the [`data`](https://tools.ietf.org/html/rfc2397) scheme is supported."
                       if:
                         - variant: openshift
             - name: mode


### PR DESCRIPTION
Allows for 
```yml
      - local_butane:
          files_dir: "." # relative to imported butane file, so here we'll go from `services/`
          path: services/systemd.bu.yml
```